### PR TITLE
[CW] [74731384] Fix Pattern Class Matching When A Hash in the DSL

### DIFF
--- a/lib/pinball_wizard/dsl.rb
+++ b/lib/pinball_wizard/dsl.rb
@@ -1,3 +1,5 @@
+require 'pinball_wizard/helpers/hash'
+
 module PinballWizard
   module DSL
     def self.build(&block)
@@ -14,15 +16,16 @@ module PinballWizard
       end
 
       def feature(name, *options)
-        feature = build_feature(name, *options)
+        options = Helpers::Hash.normalize_options(options)
+        feature = build_feature(name, options)
         Registry.add(feature)
       end
 
-      def build_feature(name, *options)
+      def build_feature(name, options)
         class_patterns_repo.each_pair do |key, klass|
-          return klass.new(name, *options) if options.include?(key)
+          return klass.new(name, options) if options.keys.include?(key)
         end
-        Feature.new(name, *options)
+        Feature.new(name, options)
       end
 
       def class_patterns(hash)

--- a/lib/pinball_wizard/feature.rb
+++ b/lib/pinball_wizard/feature.rb
@@ -5,9 +5,9 @@ module PinballWizard
     attr_reader :name, :active, :options
     attr_reader :disabled, :message
 
-    def initialize(name, *options)
+    def initialize(name, options = {})
       @name      = name.to_s
-      options    = Helpers::Hash.normalize_options(options)
+      @options   = options
       @active    = ensure_callable(options.fetch(:active, false))
       @options   = Helpers::Hash.without(options, :name, :active)
       @disabled  = false

--- a/spec/pinball_wizard/dsl_spec.rb
+++ b/spec/pinball_wizard/dsl_spec.rb
@@ -24,7 +24,7 @@ describe PinballWizard::DSL do
         })
       end
 
-      it 'createa a Feature class instance' do
+      it 'creates a Feature class instance' do
         expect(PinballWizard::Registry.get('example_a')).to be_a(PinballWizard::Feature)
       end
     end
@@ -36,26 +36,36 @@ describe PinballWizard::DSL do
       before(:each) do
         PinballWizard::DSL.build do
           class_patterns my_custom_feature: MyCustomFeature
+
           feature :example_a, :my_custom_feature
-          feature :example_b
+          feature :example_b, :foo, my_custom_feature: { b: true }
+          feature :example_c
         end
       end
 
       it 'adds to the registry' do
         expect(PinballWizard::Registry.to_h).to eq({
           'example_a' => 'inactive',
-          'example_b' => 'inactive'
+          'example_b' => 'inactive',
+          'example_c' => 'inactive'
         })
       end
 
-      it 'createa a custom class instance for the specified' do
+      it 'creates a custom class instance when given a symbol' do
         expect(PinballWizard::Registry.get('example_a')).to be_a(MyCustomFeature)
       end
 
-      it 'createa a Feature class instance for the non-specified' do
-        expect(PinballWizard::Registry.get('example_b')).to be_a(PinballWizard::Feature)
+      it 'creates a custom class instance when given a hash' do
+        expect(PinballWizard::Registry.get('example_b')).to be_a(MyCustomFeature)
       end
 
+      it 'createa a Feature class instance for the non-specified' do
+        expect(PinballWizard::Registry.get('example_c')).to be_a(PinballWizard::Feature)
+      end
+
+      it 'passes on symbols and hash into Feature options' do
+        expect(PinballWizard::Registry.get('example_b').options).to eq({ foo: true, my_custom_feature: { b: true } })
+      end
     end
   end
 end

--- a/spec/pinball_wizard/feature_spec.rb
+++ b/spec/pinball_wizard/feature_spec.rb
@@ -82,19 +82,9 @@ describe PinballWizard::Feature do
   end
 
   describe '.new' do
-    it 'takes in an array of symbols and converts them to a hash' do
-      feature = PinballWizard::Feature.new 'example', :foo, :bar
-      expect(feature.options).to eq({ foo: true, bar: true })
-    end
-
     it 'takes a hash of options' do
       feature = PinballWizard::Feature.new 'example', foo: 'bar'
       expect(feature.options).to eq({ foo: 'bar' })
-    end
-
-    it 'merges an array of symbols and hash of options' do
-      feature = PinballWizard::Feature.new 'example', :a, :b, foo: 'bar'
-      expect(feature.options).to eq({ a: true, b: true, foo: 'bar' })
     end
   end
 end


### PR DESCRIPTION
- When adding a feature in the DSL, using a key with a hash value did
  not correctly match the class and created a default Feature.

Example –

``` ruby
PinballWizard::DSL.build do
  class_patterns my_option: PinballWizard::MyFeature

  feature :example, my_option: { foo: 'bar' }
end
```

Before this fix, `:example` would be a `PinballWizard::Feature` instance. Now it is the expected `PinballWizard::MyFeature` instance.
