### PR TITLE
[CW] [105708374] Permanently Activate Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ define ['pinball_wizard'], (pinball) ->
         # Do something
 ```
 
-## Activating and Testing Features
+## Activating Features for Testing (once)
 
 ### With a URL Param
 Add `pinball` to the URL (e.g. `?pinball=example_a,example_b`).
@@ -156,7 +156,25 @@ activated while debugging.
 ```javascript
 pinball.activate('example','source name');
 ```
+## Activating Features (permanently)
 
+To turn on and keep a feature on, you can activate it permanently in the console. This is only for your browser's session.
+
+```javascript
+pinball.activatePermanently('example')
+```
+
+#### See a List of Permanent Features
+
+```javascript
+pinball.permanent()
+```
+
+#### Reset Permanent Features
+
+```javascript
+pinball.resetPermanent()
+```
 
 ## JsConfig
 The application keeps a list of features and passes them in the JsConfig object (e.g. `window.ApartmentGuide`). These define what's available and activated on page load. AG is hooked up to PinballWizard to automatically be aware of these. No additional code is necessary.

--- a/dist/css_tagger.js
+++ b/dist/css_tagger.js
@@ -1,13 +1,13 @@
 (function() {
   define(function() {
     return function(ele, pinballQueue, searchQuery) {
-      var add, classNames, entry, feature, featureNames, matches, state, _i, _j, _len, _len1, _ref;
+      var add, classNames, entry, feature, featureNames, i, j, len, len1, matches, ref, state;
       classNames = [];
       add = function(name) {
         return classNames.push('use-' + name.split('_').join('-'));
       };
-      for (_i = 0, _len = pinballQueue.length; _i < _len; _i++) {
-        entry = pinballQueue[_i];
+      for (i = 0, len = pinballQueue.length; i < len; i++) {
+        entry = pinballQueue[i];
         if (!entry.length) {
           continue;
         }
@@ -16,9 +16,9 @@
             add(entry[1]);
             break;
           case 'add':
-            _ref = entry[1];
-            for (feature in _ref) {
-              state = _ref[feature];
+            ref = entry[1];
+            for (feature in ref) {
+              state = ref[feature];
               if (state === 'active') {
                 add(feature);
               }
@@ -28,8 +28,8 @@
       matches = searchQuery.match(/pinball=([a-z-_,]+)/i);
       if (matches && matches.length > 1) {
         featureNames = (matches[1] + '').split(',');
-        for (_j = 0, _len1 = featureNames.length; _j < _len1; _j++) {
-          feature = featureNames[_j];
+        for (j = 0, len1 = featureNames.length; j < len1; j++) {
+          feature = featureNames[j];
           add(feature);
         }
       }

--- a/dist/css_tagger.min.js
+++ b/dist/css_tagger.min.js
@@ -1,3 +1,0 @@
-// Minified on http://closure-compiler.appspot.com/ using Advanced settings
-
-(function(g,d,e){var f,h,b,a,c,l,k;h=[];f=function(a){h.push("use-"+a.split("_").join("-"))};c=0;for(l=d.length;c<l;c++)if(b=d[c],b.length)switch(b[0]){case "activate":f(b[1]);break;case "add":for(a in k=b[1],k)b=k[a],"active"===b&&f(a)}if((a=e.match(/pinball=([a-z-_,]+)/i))&&1<a.length)for(d=(a[1]+"").split(","),e=0,c=d.length;e<c;e++)a=d[e],f(a);g&&(g.className+=" "+h.join(" "))})(document.documentElement,window.pinball,window.location.search);

--- a/dist/pinball_wizard.js
+++ b/dist/pinball_wizard.js
@@ -1,55 +1,55 @@
 (function() {
   'use strict';
-  var __slice = [].slice;
+  var slice = [].slice;
 
   define(function() {
-    var activate, add, addCSSClassName, cssClassName, deactivate, debug, exports, features, get, isActive, logPrefix, push, removeCSSClassName, reset, showLog, state, subscribe, subscribers, update, urlValues, _buildSubscriber, _log, _notifySubscriberOnActivate, _notifySubscribersOnActivate, _notifySubscribersOnDeactivate, _urlValueMatches, _urlValues;
+    var _buildSubscriber, _log, _notifySubscriberOnActivate, _notifySubscribersOnActivate, _notifySubscribersOnDeactivate, _urlValueMatches, _urlValues, activate, activateAllPermanent, activatePermanently, add, addCSSClassName, appendPermanent, cssClassName, deactivate, debug, exports, features, get, isActive, logPrefix, permanent, push, removeCSSClassName, reset, resetPermanent, setPermanent, showLog, state, storage, subscribe, subscribers, update, urlValues;
     features = {};
     subscribers = {};
     showLog = false;
     logPrefix = '[PinballWizard]';
     _log = function() {
       var args, message;
-      message = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
+      message = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
       if (showLog && window.console && window.console.log) {
-        console.log.apply(console, ["" + logPrefix + " " + message].concat(__slice.call(args)));
+        console.log.apply(console, [logPrefix + " " + message].concat(slice.call(args)));
       }
     };
     _notifySubscribersOnActivate = function(name) {
-      var subscriber, _i, _len, _ref, _results;
+      var i, len, ref, results, subscriber;
       if (subscribers[name] == null) {
         subscribers[name] = [];
       }
-      _ref = subscribers[name];
-      _results = [];
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        subscriber = _ref[_i];
-        _results.push(_notifySubscriberOnActivate(subscriber, name));
+      ref = subscribers[name];
+      results = [];
+      for (i = 0, len = ref.length; i < len; i++) {
+        subscriber = ref[i];
+        results.push(_notifySubscriberOnActivate(subscriber, name));
       }
-      return _results;
+      return results;
     };
     _notifySubscriberOnActivate = function(subscriber, name) {
       _log('Notify subscriber that %s is active', name);
       return subscriber.onActivate();
     };
     _notifySubscribersOnDeactivate = function(name) {
-      var subscriber, _i, _len, _ref, _results;
+      var i, len, ref, results, subscriber;
       if (subscribers[name] == null) {
         subscribers[name] = [];
       }
-      _ref = subscribers[name];
-      _results = [];
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        subscriber = _ref[_i];
-        _results.push(subscriber.onDeactivate());
+      ref = subscribers[name];
+      results = [];
+      for (i = 0, len = ref.length; i < len; i++) {
+        subscriber = ref[i];
+        results.push(subscriber.onDeactivate());
       }
-      return _results;
+      return results;
     };
     _urlValueMatches = function(value) {
-      var v, _i, _len, _ref;
-      _ref = _urlValues();
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        v = _ref[_i];
+      var i, len, ref, v;
+      ref = _urlValues();
+      for (i = 0, len = ref.length; i < len; i++) {
+        v = ref[i];
         if (value === v) {
           return true;
         }
@@ -57,14 +57,14 @@
       return false;
     };
     _urlValues = function(search) {
-      var key, pair, pairs, value, _i, _len, _ref;
+      var i, key, len, pair, pairs, ref, value;
       if (search == null) {
         search = window.location.search;
       }
       pairs = search.substr(1).split('&');
-      for (_i = 0, _len = pairs.length; _i < _len; _i++) {
-        pair = pairs[_i];
-        _ref = pair.split('='), key = _ref[0], value = _ref[1];
+      for (i = 0, len = pairs.length; i < len; i++) {
+        pair = pairs[i];
+        ref = pair.split('='), key = ref[0], value = ref[1];
         if (key === 'pinball' && (value != null)) {
           return value.split(',');
         }
@@ -99,21 +99,21 @@
       }
     };
     add = function(list) {
-      var name, state, _results;
-      _results = [];
+      var name, results, state;
+      results = [];
       for (name in list) {
         state = list[name];
         features[name] = state;
         _log("Added %s: %s.", name, state);
         if (isActive(name)) {
-          _results.push(activate(name, "automatic. added as '" + state + "'"));
+          results.push(activate(name, "automatic. added as '" + state + "'"));
         } else if (_urlValueMatches(name, urlValues)) {
-          _results.push(activate(name, 'URL'));
+          results.push(activate(name, 'URL'));
         } else {
-          _results.push(void 0);
+          results.push(void 0);
         }
       }
-      return _results;
+      return results;
     };
     get = function(name) {
       return features[name];
@@ -187,6 +187,36 @@
       method = params.shift();
       return this[method].apply(this, params);
     };
+    storage = window.localStorage;
+    setPermanent = function(value) {
+      return storage.setItem('pinball_wizard', JSON.stringify(value));
+    };
+    appendPermanent = function(name) {
+      var l;
+      l = permanent();
+      l.push(name);
+      return setPermanent(l);
+    };
+    permanent = function() {
+      return JSON.parse(storage.getItem('pinball_wizard') || "[]") || [];
+    };
+    activatePermanently = function(name) {
+      appendPermanent(name);
+      return activate(name, 'permanent');
+    };
+    resetPermanent = function() {
+      return setPermanent([]);
+    };
+    activateAllPermanent = function() {
+      var i, len, name, ref, results;
+      ref = permanent();
+      results = [];
+      for (i = 0, len = ref.length; i < len; i++) {
+        name = ref[i];
+        results.push(activate(name));
+      }
+      return results;
+    };
     state = function() {
       return features;
     };
@@ -210,7 +240,11 @@
       cssClassName: cssClassName,
       addCSSClassName: addCSSClassName,
       removeCSSClassName: removeCSSClassName,
-      _urlValues: _urlValues
+      _urlValues: _urlValues,
+      activatePermanently: activatePermanently,
+      resetPermanent: resetPermanent,
+      permanent: permanent,
+      activateAllPermanent: activateAllPermanent
     };
     if (typeof window !== "undefined" && window !== null ? window.pinball : void 0) {
       if (_urlValueMatches('debug')) {
@@ -221,6 +255,7 @@
       }
       window.pinball = exports;
     }
+    activateAllPermanent();
     return exports;
   });
 

--- a/src/pinball_wizard.coffee
+++ b/src/pinball_wizard.coffee
@@ -120,6 +120,31 @@ define ->
     method = params.shift()
     @[method].apply(@, params)
 
+
+  storage = window.localStorage
+
+  setPermanent = (value) ->
+    storage.setItem('pinball_wizard', JSON.stringify(value))
+
+  appendPermanent = (name) ->
+    l = permanent()
+    l.push(name)
+    setPermanent l
+
+  permanent = ->
+    JSON.parse(storage.getItem('pinball_wizard') or "[]") or []
+
+  activatePermanently = (name) ->
+    appendPermanent(name)
+    activate(name, 'permanent')
+
+  resetPermanent = ->
+    setPermanent []
+
+  activateAllPermanent = ->
+    for name in permanent()
+      activate(name)
+
   state = ->
     features
 
@@ -145,6 +170,10 @@ define ->
     addCSSClassName
     removeCSSClassName
     _urlValues
+    activatePermanently
+    resetPermanent
+    permanent
+    activateAllPermanent
   }
 
   # Initialize
@@ -153,5 +182,7 @@ define ->
     while window.pinball.length
       exports.push window.pinball.shift()
     window.pinball = exports
+
+  activateAllPermanent()
 
   exports

--- a/test/spec/pinball_wizard_spec.coffee
+++ b/test/spec/pinball_wizard_spec.coffee
@@ -266,3 +266,45 @@ define ['pinball_wizard'], (pinball) ->
     it 'works with other keys/values', ->
       urlParam = '?foo=bar&pinball=a,b&bar'
       expect(pinball._urlValues(urlParam)).toEqual(['a','b'])
+
+  describe '#activatePermanent', ->
+    beforeEach ->
+      pinball.add
+        my_feature: 'inactive'
+      pinball.activatePermanently('my_feature')
+
+    it 'adds it to the list of permanent', ->
+      expect(pinball.permanent()).toEqual(['my_feature'])
+
+    it 'activates the feature', ->
+      expect(pinball.isActive('my_feature')).toEqual(true)
+
+  describe '#permanent', ->
+    beforeEach ->
+      pinball.resetPermanent()
+      pinball.add
+        my_feature: 'inactive'
+
+    it 'is empty by default', ->
+      expect(pinball.permanent()).toEqual([])
+
+    it 'builds a list of those permanent', ->
+      pinball.activatePermanently('my_feature')
+      expect(pinball.permanent()).toEqual(['my_feature'])
+
+    it 'is empty after resetting', ->
+      pinball.activatePermanently('my_feature')
+      pinball.resetPermanent()
+      expect(pinball.permanent()).toEqual([])
+
+  describe '#activateAllPermanent', ->
+    beforeEach ->
+      pinball.resetPermanent()
+      pinball.add
+        my_feature: 'inactive'
+
+    it 'is active', ->
+      pinball.activatePermanently('my_feature')
+      pinball.deactivate 'my_feature'
+      pinball.activateAllPermanent()
+      expect(pinball.isActive('my_feature')).toEqual(true)


### PR DESCRIPTION
- Added `#activatePermanently` which activates a feature and keeps it active in `localStorage`.
- Added `#resetPermanent` which clears all permanent.
- Added `#permanent` which lists out features turned on.

`window.localStorage` is used to activate features and keep them on in your browser. This is useful for testing features than span across multiple URLs and are inactive by default.

This will become `v0.4.0` after merging.