### PR TITLE
CSS Tagger honors permanent features

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,12 +176,38 @@ pinball.permanent()
 pinball.resetPermanent()
 ```
 
-## JsConfig
-The application keeps a list of features and passes them in the JsConfig object (e.g. `window.ApartmentGuide`). These define what's available and activated on page load. AG is hooked up to PinballWizard to automatically be aware of these. No additional code is necessary.
+## JsConfig Registry
+The application keeps a list of features and passes them in the JsConfig object (e.g. `window.pinball`). These define what's available and activated on page load.
 
-`{ "feature_name": "state", "feature_name": "state" }`
+#### Plain JavaScript
+```javascript
+<head>
+  <script type="text/javascript">
+	window.pinball = window.pinball || []
+    window.pinball.push(['add', { "feature_a": "active", "feature_b": "inactive", "feature_c": "disabled" }]);
+  </script>
+<head>
+```
 
-e.g. `{ "feature_a": "active", "feature_b": "inactive", "feature_c": "disabled" }`
+#### Ruby (example is in slim)
+```slim
+head
+  javascript:
+    window.pinball = window.pinball || [];
+    window.pinball.push(['add', #{{PinballWizard::Registry.to_h.to_json}}]);
+```
+
+## Removing the Flicker
+
+When using `.use-{feature-name}`, you may notice a shift or flicker in the UI. This occurs when pinball's JavaScript executes after the `DOMContentReady` event. To prevent this, add `dist/css_tagger.min.js` into your `<head>` tag. For example:
+
+```html
+<head>
+	<script type="text/javascript">
+		// paste snippet from dist/css_tagger.min.js
+	</script>
+</head>
+```
 
 ## Debugging
 

--- a/dist/css_tagger.js
+++ b/dist/css_tagger.js
@@ -1,7 +1,7 @@
 (function() {
   define(function() {
     return function(ele, pinballQueue, searchQuery) {
-      var add, classNames, entry, feature, featureNames, i, j, len, len1, matches, ref, state;
+      var add, classNames, entry, feature, featureNames, i, j, k, len, len1, len2, matches, ref, ref1, state, storage;
       classNames = [];
       add = function(name) {
         return classNames.push('use-' + name.split('_').join('-'));
@@ -32,6 +32,14 @@
           feature = featureNames[j];
           add(feature);
         }
+      }
+      storage = window.localStorage || {
+        setItem: function() {}
+      };
+      ref1 = JSON.parse(storage.getItem('pinball_wizard')) || [];
+      for (k = 0, len2 = ref1.length; k < len2; k++) {
+        feature = ref1[k];
+        add(feature);
       }
       if (ele) {
         ele.className += ' ' + classNames.join(' ');

--- a/dist/css_tagger.min.js
+++ b/dist/css_tagger.min.js
@@ -1,0 +1,3 @@
+// Minified on http://closure-compiler.appspot.com/ using Advanced settings
+
+(function(h,c,f){var g,k,e,b,d,l,m;k=[];g=function(b){k.push("use-"+b.split("_").join("-"))};d=0;for(l=c.length;d<l;d++)if(e=c[d],e.length)switch(e[0]){case "activate":g(e[1]);break;case "add":for(b in e=e[1],e)m=e[b],"active"===m&&g(b)}if((b=f.match(/pinball=([a-z-_,]+)/i))&&1<b.length)for(c=(b[1]+"").split(","),f=0,d=c.length;f<d;f++)b=c[f],g(b);d=JSON.parse((window.localStorage||{setItem:function(){}}).getItem("pinball_wizard"))||[];c=0;for(f=d.length;c<f;c++)b=d[c],g(b);h&&(h.className+=" "+k.join(" "))})(document.documentElement,window.pinball,window.location.search);

--- a/src/css_tagger.coffee
+++ b/src/css_tagger.coffee
@@ -21,6 +21,7 @@ define ->
     add = (name) ->
       classNames.push 'use-' + name.split('_').join('-')
 
+    # Activated by the queue
     for entry in pinballQueue
       continue unless entry.length
 
@@ -32,12 +33,19 @@ define ->
           for feature, state of entry[1]
             add feature if state == 'active'
 
+    # Activated by the URL
     matches = searchQuery.match(/pinball=([a-z-_,]+)/i)
     if matches && matches.length > 1
       featureNames = (matches[1] + '').split(',')
 
       for feature in featureNames
         add feature
+
+
+    # Activated permanently
+    storage = window.localStorage or { setItem: -> }
+    for feature in (JSON.parse(storage.getItem('pinball_wizard')) or [])
+      add feature
 
     ele.className += ' ' + classNames.join(' ') if ele
 

--- a/test/spec/css_tagger_spec.coffee
+++ b/test/spec/css_tagger_spec.coffee
@@ -48,3 +48,20 @@ define ['css_tagger'], (tagger) ->
 
       tagger ele, pinballQueue, '?pinball=feature_c'
       expect(ele.className).toEqual ' use-feature-a use-feature-b use-feature-c'
+
+    it 'should add classes from the permanent storage', ->
+      ele = document.createElement 'div'
+      window.localStorage.setItem 'pinball_wizard', JSON.stringify(['feature_a','feature_b'])
+
+      tagger ele, [], ''
+      expect(ele.className).toEqual ' use-feature-a use-feature-b'
+
+      # Cleanup
+      window.localStorage.setItem 'pinball_wizard', null
+
+    it 'should not add any when permanent storage is null', ->
+      ele = document.createElement 'div'
+      window.localStorage.setItem 'pinball_wizard', null
+
+      tagger ele, [], ''
+      expect(ele.className).toEqual ''


### PR DESCRIPTION
- CSS tagger now looks at permanent features and adds the appropriate CSS class to `<html>`.
- Added documentation for CSS tagger.
- Restored `dist/css_tagger.min.js` (accidentally removed in v0.4.0).

In short, this prevents UI flickering :D